### PR TITLE
Only paste allowed editors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/buttons.less
+++ b/src/Umbraco.Web.UI.Client/src/less/buttons.less
@@ -60,7 +60,7 @@
 
 }
 
-.btn-group>.btn+.dropdown-toggle {
+.btn-group>.btn~.dropdown-toggle {
     box-shadow: none;
     -webkit-box-shadow:none;
 }

--- a/src/Umbraco.Web.UI.Client/src/less/canvas-designer.less
+++ b/src/Umbraco.Web.UI.Client/src/less/canvas-designer.less
@@ -132,7 +132,7 @@ a, a:hover{
     color: #ffffff;
 }
 
-.btn-group > .btn + .dropdown-toggle {
+.btn-group > .btn ~ .dropdown-toggle {
     -webkit-box-shadow: none;
     box-shadow: none;
 }
@@ -141,7 +141,7 @@ a, a:hover{
     margin-left: -6px;
 }
 
-.btn-group > .btn + .dropdown-toggle {
+.btn-group > .btn ~ .dropdown-toggle {
     padding-right: 8px;
     padding-left: 8px;
     -webkit-box-shadow: inset 1px 0 0 rgba(255, 255, 255, 0.125), inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -645,18 +645,36 @@ angular.module("umbraco")
           setClipboard();
         }
 
-        $scope.paste = function (event, cell, index, copied) {
-          var newControl = $.extend({}, copied);
-          if (copied && copied.editor) {
+		$scope.allowedEditorsInClipboard = function (cell) {
+			var allowedEditors = cell.$allowedEditors.map(function (editor) { return editor.alias; });
+			return $scope.clipboard.filter(function (control) {
+				return allowedEditors.indexOf(control.editor.alias) > -1;
+			});
+		}
 
-            if (index === undefined) {
-              index = cell.controls.length;
+		$scope.paste = function (event, cell, index, copied) {
+			if (typeof (copied) == "undefined") {
+				// should be first allowed editor
+				var allowedEditors = $scope.allowedEditorsInClipboard(cell);
+				if (allowedEditors.length == 0) {
+					return false;
+				}
+				else {
+					copied = allowedEditors[allowedEditors.length - 1];
+				}
+			}
+
+            var newControl = $.extend({}, copied);
+            if (copied && copied.editor) {
+
+                if (index === undefined) {
+                  index = cell.controls.length;
+                }
+
+                newControl.active = true;
+                $scope.initControl(newControl, index + 1);
+                cell.controls.push(newControl);
             }
-
-            newControl.active = true;
-            $scope.initControl(newControl, index + 1);
-            cell.controls.push(newControl);
-          }
         }
 
         // *********************************************

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.html
@@ -229,16 +229,16 @@
                                                       <div class="umb-grid-add-more-content" ng-if="area.controls.length > 0 && !sortMode">
                                                           <div class="cell-tools-add -bar newbtn" ng-click="openEditorOverlay($event, area, 0, area.$uniqueId);"><localize key="grid_addElement"/>
                                                           </div>
-                                                      <div class="cell-tools-button btn-group dropup" ng-if="clipboard.length > 0">
-                                                          <button type="button" class="btn umb-button__button" ng-click="paste($event, area, 0, clipboard[clipboard.length-1])">
+                                                      <div class="cell-tools-button btn-group dropup" ng-if="allowedEditorsInClipboard(area).length > 0">
+                                                          <button type="button" class="btn umb-button__button" ng-click="paste($event, area, 0)">
                                                               <i class="icon icon-paste-in"></i>
                                                               <localize key="grid_pasteElement" />
                                                         </button>
-                                                          <button ng-if="clipboard.length > 1" type="button" class="btn umb-button__button dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                                          <button ng-if="allowedEditorsInClipboard(area).length > 1" type="button" class="btn umb-button__button dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                                               <span class="caret"></span>
                                                           </button>
-                                                          <ul ng-if="clipboard.length > 1" class="dropdown-menu">
-                                                              <li ng-repeat="control in clipboard">
+                                                          <ul ng-if="allowedEditorsInClipboard(area).length > 1" class="dropdown-menu dropdown-menu-right">
+                                                              <li ng-repeat="control in allowedEditorsInClipboard(area)">
                                                                   <a ng-click="paste($event, area, 0, control)">
                                                                       <i class="icon {{ control.editor.icon }}"></i>
                                                                       <span ng-bind="control.editor.name"></span>


### PR DESCRIPTION
This updates the paste button, so it's only visible when there are allowed editors in the clipboard. Also updates the dropup list.

Also, theres some css fixes so @bjarnef doesn't have to :)