### PR TITLE
Set unique guid on copy

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js
@@ -626,13 +626,15 @@ angular.module("umbraco")
         }
 
         setClipboard();
-  
+
         $scope.copy = function(control) {
           if (!Array.isArray(localStorageService.get(gridClipboardAlias))) {
             localStorageService.set(gridClipboardAlias, []);
           }
 
           var newClipboard = localStorageService.get(gridClipboardAlias);
+
+          control.guid = $scope.setUniqueId();
 
           newClipboard.push(control);
 


### PR DESCRIPTION
Hi @lars-erik,

I've been using the package published by Søren (https://our.umbraco.org/projects/backoffice-extensions/copy-paste-grid-editors/) with great pleasure.

I did however expierence some issues with duplicate frontend LeBlender elements where a copied element is shown twice with the same data as the one copied from even though it was changed after copy. This usally happens if you copy a element and use it on the same page.

It only happens in the frontend and doesn't happen if you e.g. turn of LeBlender cache for the specific element. I then found out that a copied element uses the same guid as the one it was copied from which seems to cause these issues. 

I have therefore implemented this fix which creates a unique guid when copying the element :-)